### PR TITLE
added labels with metadata for build avoidance

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
             context: .
             dockerfile: Dockerfile
             labels:
+                container.build.time: $CONTAINER_BUILD_TIME
                 container.fingerprint: $CONTAINER_FINGERPRINT
                 container.git.branch: $CONTAINER_GIT_BRANCH
                 container.git.commit: $CONTAINER_GIT_COMMIT


### PR DESCRIPTION
* fixup LABELS to use for build avoidance
* introduced BASE_TAG to reference image that a container is based upon
* updated docker-compose.yml to move LABELS from runtime to buildtime
* fixed "container.original.name" in docker-compose.yml